### PR TITLE
[Feat]  Cart [GET] 로컬스토리지 'cartItems' 작품정보 목록 중 고유아이디만 뽑아서 서버에 재고 확인 …

### DIFF
--- a/client/src/components/Cart/CartList.tsx
+++ b/client/src/components/Cart/CartList.tsx
@@ -74,7 +74,7 @@ export const CartList = ({ cartProductState }: CartProductsProps) => {
               <dt>{el.title}</dt>
               <dd>{el.artist.name}</dd>
               <dd>{`${el.info.size} (${el.info.canvas}호)`}</dd>
-              <dd>{`${useComma(el.price)} 원`}</dd>
+              <dd>{el.inStock ? `${useComma(el.price)} 원` : `품절`}</dd>
             </ProductDlWrap>
           </ProductContent>
         );

--- a/client/src/components/Cart/CartPay.tsx
+++ b/client/src/components/Cart/CartPay.tsx
@@ -1,4 +1,5 @@
 import { TiEquals, TiPlus } from 'react-icons/ti';
+import { useComma } from 'util/functions';
 import {
   CartPayWrap,
   CartPayContentWrap,
@@ -7,14 +8,14 @@ import {
   CartPayClickBtn,
 } from './styled';
 
-export const CartPay = () => {
+export const CartPay = ({ totalPriceState }: { totalPriceState: number }) => {
   return (
     <CartPayWrap>
       <CartPayContentWrap>
         <CartPayCountWrap>
           <CartPayDescriptionWrap>
             <dt>총 상품 금액</dt>
-            <dd>80,000원</dd>
+            <dd>{`${useComma(totalPriceState)}원`}</dd>
           </CartPayDescriptionWrap>
           <TiPlus />
           <CartPayDescriptionWrap>
@@ -24,7 +25,7 @@ export const CartPay = () => {
           <TiEquals />
           <CartPayDescriptionWrap>
             <dt>결제예정금액</dt>
-            <dd>90,000원</dd>
+            <dd>{`${useComma(totalPriceState + 10000)}원`}</dd>
           </CartPayDescriptionWrap>
         </CartPayCountWrap>
         <CartPayClickBtn type="button">주문하기</CartPayClickBtn>

--- a/client/src/components/Cart/styled.ts
+++ b/client/src/components/Cart/styled.ts
@@ -253,6 +253,12 @@ export const ListDeleteBtnWrap = styled.div`
     height: 100%;
     border: none;
     background: none;
+    transition: all 0.5s;
+  }
+
+  & button:hover {
+    cursor: pointer;
+    transform: scale(1.1);
   }
 
   & button svg {

--- a/client/src/pages/CartPage/Cart.tsx
+++ b/client/src/pages/CartPage/Cart.tsx
@@ -39,6 +39,8 @@ const Cart = () => {
     },
   ]);
 
+  const [totalPriceState, setTotalPriceState] = useState<number>(0);
+
   // 로컬스토리지 갱신을 위한 useEffect
   useEffect(() => {
     const localInfo = localStorage.getItem('cartItems');
@@ -58,7 +60,14 @@ const Cart = () => {
   }, [cartListState]);
 
   useEffect(() => {
-    console.log(cartProductState);
+    setTotalPriceState(
+      cartProductState.reduce((acc, cur) => {
+        if (cur.inStock) {
+          return acc + cur.price;
+        }
+        return acc;
+      }, 0),
+    );
   }, [cartProductState]);
 
   return (
@@ -72,7 +81,7 @@ const Cart = () => {
           <CartMenu />
           <CartList cartProductState={cartProductState} />
         </CartContentLeftWrap>
-        <CartPay />
+        <CartPay totalPriceState={totalPriceState} />
       </CartContentWrap>
       <Footer />
     </CartContainer>


### PR DESCRIPTION

<!--
  PR 작성 가이드
1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
2. emoji, @어노테이션 등을 사용하여 효과적으로 소통할 것.
3. 명확하게 질문하고 명확하게 답변할 것.
4. 새로운 모듈 설치시 PR message에 기재할 것.
5. PR 올리기전에 branch 반드시 확인할 것. 
-->

## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
- Cart [GET] 로컬스토리지 'cartItems' 작품정보 목록 중 고유아이디만 뽑아서 서버에 재고 확인 
## 👩‍💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
-  [GET] 로컬스토리지 'cartItems' 작품정보 목록 중 고유아이디만 뽑아서 서버에 재고 확인 요청
성공 : 품절여부 목록 받아서 로컬스토리지 작품 목록 상태(inStock) 업데이트 후 맵으로 랜더링
true (재고 O) : 금액 표시
false (재고 X) : 품절 표시
재고 있는 작품만 금액 더해서 총 작품금액 랜더링(필터로 품절인녀석은 빼고 맵으로 계산)

close #50 
