### PR TITLE
[Feat] Cart 품절 작품 삭제 기능 구현 Close #53

### DIFF
--- a/client/src/components/Cart/CartMenu.tsx
+++ b/client/src/components/Cart/CartMenu.tsx
@@ -1,7 +1,34 @@
+/* eslint no-underscore-dangle: 0 */
+import instance from 'util/axios';
+import { OrderProducts } from 'util/type';
 import { VscPass } from 'react-icons/vsc';
 import { CartMenuWrap, AllSelectBtnWrap, SelectBtnWrap } from './styled';
 
 export const CartMenu = () => {
+  const soldoutDeleteHandler = () => {
+    const cartItems = localStorage.getItem('cartItems');
+    const arr = JSON.parse(cartItems || '{}');
+    instance
+      .get('/products/cart-items', { params: { productId: arr } })
+      .then((res) => {
+        const newArr = res.data.filter((el: OrderProducts) => {
+          return el.inStock === true;
+        });
+        localStorage.setItem(
+          'cartItems',
+          JSON.stringify(
+            newArr.map((el: OrderProducts) => {
+              return el._id;
+            }),
+          ),
+        );
+        window.location.reload();
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  };
+
   return (
     <CartMenuWrap>
       <AllSelectBtnWrap>
@@ -13,7 +40,9 @@ export const CartMenu = () => {
         </button>
       </AllSelectBtnWrap>
       <SelectBtnWrap>
-        <button type="button">품절상품삭제</button>
+        <button type="button" onClick={soldoutDeleteHandler}>
+          품절상품삭제
+        </button>
         <button type="button">선택상품삭제</button>
       </SelectBtnWrap>
     </CartMenuWrap>


### PR DESCRIPTION
- [GET] 로컬스토리지 'cartItems' 작품정보 목록 중 고유아이디만 뽑아서 서버에 재고 확인 요청
성공 : 품절여부 목록 받아서 로컬스토리지 작품 목록 상태(inStock) 업데이트 후 false인 작품만 필터링하여 맵으로 렌더링

<!--
  PR 작성 가이드
1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
2. emoji, @어노테이션 등을 사용하여 효과적으로 소통할 것.
3. 명확하게 질문하고 명확하게 답변할 것.
4. 새로운 모듈 설치시 PR message에 기재할 것.
5. PR 올리기전에 branch 반드시 확인할 것. 
-->

## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
- Cart 품절 작품 삭제 기능 구현
## 👩‍💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
- [GET] 로컬스토리지 'cartItems' 작품정보 목록 중 고유아이디만 뽑아서 서버에 재고 확인 요청
성공 : 품절여부 목록 받아서 로컬스토리지 작품 목록 상태(inStock) 업데이트 후 false인 작품만 필터링하여 맵으로 렌더링

close #53 

