### PR TITLE
[Feat] Order 결제 버튼 기능 구현 Close #59

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -15,6 +15,7 @@
         "@types/uuid": "^8.3.3",
         "axios": "^0.24.0",
         "dotenv": "^10.0.0",
+        "jquery": "^3.6.0",
         "react": "^17.0.2",
         "react-aws-s3": "^1.5.0",
         "react-aws-s3-typescript": "^1.1.3",
@@ -12142,6 +12143,11 @@
       "engines": {
         "node": ">= 0.6.0"
       }
+    },
+    "node_modules/jquery": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
+      "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -30869,6 +30875,11 @@
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
       "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+    },
+    "jquery": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
+      "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/client/package.json
+++ b/client/package.json
@@ -10,6 +10,7 @@
     "@types/uuid": "^8.3.3",
     "axios": "^0.24.0",
     "dotenv": "^10.0.0",
+    "jquery": "^3.6.0",
     "react": "^17.0.2",
     "react-aws-s3": "^1.5.0",
     "react-aws-s3-typescript": "^1.1.3",

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -35,5 +35,15 @@
       type="text/javascript"
       charset="utf-8"
     ></script>
+    <!-- jQuery -->
+    <script
+      type="text/javascript"
+      src="https://code.jquery.com/jquery-1.12.4.min.js"
+    ></script>
+    <!-- iamport.payment.js -->
+    <script
+      type="text/javascript"
+      src="https://cdn.iamport.kr/js/iamport.payment-1.1.8.js"
+    ></script>
   </body>
 </html>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -8,6 +8,7 @@ import Artists from 'pages/ArtistListPage/ArtistList';
 import Cart from 'pages/CartPage/Cart';
 import MyPage from 'pages/MyPage/MyPage';
 import Order from 'pages/OrderPage/Order';
+import PaymentFinished from 'pages/PaymentFinishedPage/PaymentFinished';
 import Zzim from 'pages/MyPage/ZzimPage/Zzim';
 import AdminOrder from 'pages/AdminOrderPage/AdminOrder';
 import AdminProduct from 'pages/AdminProductPage/AdminProduct';
@@ -34,6 +35,7 @@ function App() {
           <Route path="/artistdetail/:id" element={<ArtistDetail />} />
           <Route path="/cart" element={<Cart />} />
           <Route path="/order" element={<Order />} />
+          <Route path="/paymentfinished" element={<PaymentFinished />} />
           <Route path="/mypage" element={<MyPage />} />
           <Route path="/mypage/zzim" element={<Zzim />} />
           <Route path="/admin/order" element={<AdminOrder />} />

--- a/client/src/components/Modal/CartNotListModal.tsx
+++ b/client/src/components/Modal/CartNotListModal.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from 'react-router-dom';
 import {
   ModalBackdrop,
   ModalWrap,
@@ -12,8 +13,10 @@ type Props = {
 };
 
 const CartNotListModal = ({ clickModalHandler }: Props) => {
+  const history = useNavigate();
+
   const backMovingHanlder = () => {
-    window.history.back();
+    history('/');
   };
 
   return (
@@ -26,7 +29,7 @@ const CartNotListModal = ({ clickModalHandler }: Props) => {
           <p>아트 쇼핑백이 비어있습니다</p>
         </ContentWrap>
         <ButtonBox>
-          <SelectButton onClick={backMovingHanlder}>뒤로가기</SelectButton>
+          <SelectButton onClick={backMovingHanlder}>메인으로 가기</SelectButton>
         </ButtonBox>
       </ModalWrap>
     </ModalBackdrop>

--- a/client/src/components/Order/OrderPay.tsx
+++ b/client/src/components/Order/OrderPay.tsx
@@ -1,4 +1,17 @@
-import { useComma } from 'util/functions';
+/* eslint-disable */
+import { useComma, useName, useOrderNumber } from 'util/functions';
+import instance from 'util/axios';
+import dotenv from 'dotenv';
+import { useNavigate } from 'react-router-dom';
+import {
+  OrderDeliver,
+  OrdererUserInfo,
+  OrderDelierDetail,
+  OrderPrice,
+  OrderProducts,
+  RequestPayParams,
+  RequestPayResponse,
+} from 'util/type';
 import {
   OrderContentContainer,
   ContentWrap,
@@ -10,14 +23,169 @@ import {
 } from './styled';
 
 type PriceProps = {
-  priceState: {
-    shippingPrice: number;
-    totalPrice: number;
-  };
+  priceState: OrderPrice;
   clientPrice: number;
+  shippingState: OrderDeliver;
+  ordererInfoState: OrdererUserInfo;
+  deliveryReqState: OrderDelierDetail;
+  productState: OrderProducts[];
+  orderProduct: string[];
 };
 
-export const OrderPay = ({ priceState, clientPrice }: PriceProps) => {
+dotenv.config();
+
+declare global {
+  interface Window {
+    IMP: any;
+  }
+}
+
+export const OrderPay = ({
+  priceState,
+  clientPrice,
+  shippingState,
+  ordererInfoState,
+  deliveryReqState,
+  productState,
+  orderProduct,
+}: PriceProps) => {
+  const history = useNavigate();
+
+  const OrderPaymentHandler = () => {
+    // IAMPORT 핸들러
+    const hanldePayment = () => {
+      // 가맹점 식별코드 이용하여 IMP객체 초기화
+      const IMP = window.IMP; // 생략 가능
+      IMP.init(process.env.REACT_APP_IMPORT);
+
+      // 결제 금액
+      const amount: number = priceState.totalPrice + priceState.shippingPrice;
+      if (!amount) {
+        alert('결제 금액을 확인해주세요');
+        return;
+      }
+
+      // req 함수 data 설정
+      const data: RequestPayParams = {
+        pg: 'html5_inicis',
+        pay_method: 'card',
+        merchant_uid: useOrderNumber(),
+        name: useName(productState),
+        amount: amount,
+        buyer_name: ordererInfoState.name,
+        buyer_tel: ordererInfoState.phoneNum,
+        buyer_email: ordererInfoState.email,
+        m_redirect_url: 'http:localhost:3000',
+        app_scheme: 'http:localhost:3000',
+      };
+
+      const callback = (response: RequestPayResponse) => {
+        const {
+          success,
+          merchant_uid,
+          error_msg,
+          imp_uid,
+          error_code,
+          paid_amount,
+          name,
+          pg_tid,
+          buyer_name,
+          buyer_email,
+          buyer_tel,
+          paid_at,
+          receipt_url,
+        } = response;
+
+        if (success) {
+          // 주문에 성공했으니 서버에 주문 정보 전달
+          const orderItem = productState.map((el) => {
+            return {
+              product: el._id,
+              image: el.image,
+              title: el.title,
+              artist: el.artist.name,
+              size: `${el.info.size}(${el.info.canvas}호)`,
+              price: el.price,
+            };
+          });
+          if (
+            priceState.totalPrice + priceState.shippingPrice ===
+            response.paid_amount
+          ) {
+            instance
+              .post('/orders', {
+                orderItems: orderItem,
+                result: { id: response.merchant_uid },
+                deliveryInfo: shippingState,
+                deliveryDetails: deliveryReqState,
+                ordererInfo: ordererInfoState,
+                shippingPrice: priceState.shippingPrice,
+                totalPrice: priceState.totalPrice + priceState.shippingPrice,
+              })
+              .then((res) => {
+                const localInfo = localStorage.getItem('cartItems');
+                const newArr = JSON.parse(localInfo || '[]').filter(
+                  (el: string) => {
+                    return !orderProduct.includes(el);
+                  },
+                );
+                localStorage.setItem('cartItems', JSON.stringify(newArr));
+                history('/paymentfinished');
+              })
+              .catch((err) => {
+                // 이럴 경우에는 환불해줘야됨 꼭 구현해야 하는것
+                window.location.assign('/error');
+                console.log(err.response);
+              });
+          } else {
+            alert('결제금액이 이상합니다.');
+            window.location.assign('/error');
+          }
+        } else {
+          // 실패한 경우
+          alert('주문을 취소 하셨습니다');
+        }
+      };
+
+      IMP.request_pay(data, callback);
+    };
+
+    // 품절여부 확인
+    instance
+      .get('/products/cart-items', { params: { productId: orderProduct } })
+      .then((res) => {
+        const newArr = res.data.filter((el: OrderProducts) => {
+          return el.inStock;
+        });
+        if (newArr.length !== res.data.length) {
+          // 품절 상품이 있는경우
+          alert('품절 상품이 있습니다 품절상품 제외하고 다시 주문해주세요');
+          window.history.back();
+        } else {
+          // 결제 요청금액 확인
+          instance
+            .get('/products/total-price', {
+              params: { productId: orderProduct },
+            })
+            .then((res) => {
+              if (res.data.totalPrice && priceState.totalPrice && clientPrice) {
+                // 품절상품도 없고 결제 금액도 맞는 상태
+                hanldePayment();
+              } else {
+                // 재고는 있지만 결제금액 불일치
+                window.location.assign('/error');
+              }
+            })
+            .catch(() => {
+              window.location.assign('/error');
+            });
+        }
+      })
+      .catch(() => {
+        window.location.assign('/error');
+      });
+  };
+
   return (
     <OrderContentContainer mobile="mobile">
       <ContentWrap>
@@ -25,19 +193,23 @@ export const OrderPay = ({ priceState, clientPrice }: PriceProps) => {
         <CountWrap>
           <DescriptionWrap>
             <dt>주문금액</dt>
-            <dd>{`${useComma(priceState.shippingPrice)} 원`}</dd>
+            <dd>{`${useComma(priceState.totalPrice)} 원`}</dd>
           </DescriptionWrap>
           <DescriptionWrap>
             <dt>배송비</dt>
-            <dd>10,000 원</dd>
+            <dd>{`${useComma(priceState.shippingPrice)} 원`}</dd>
           </DescriptionWrap>
           <DescriptionWrap>
             <dt>총 결제 예정금액</dt>
-            <dd>{`${useComma(priceState.totalPrice)} 원`}</dd>
+            <dd>{`${useComma(
+              priceState.totalPrice + priceState.shippingPrice,
+            )} 원`}</dd>
           </DescriptionWrap>
         </CountWrap>
-        <ClickBtn type="button">
-          <ClickBtnSpan>{`${useComma(priceState.totalPrice)} 원`}</ClickBtnSpan>
+        <ClickBtn type="button" onClick={OrderPaymentHandler}>
+          <ClickBtnSpan>{`${useComma(
+            priceState.totalPrice + priceState.shippingPrice,
+          )}원`}</ClickBtnSpan>
           결제하기
         </ClickBtn>
       </ContentWrap>

--- a/client/src/components/Order/OrderRequestInfo.tsx
+++ b/client/src/components/Order/OrderRequestInfo.tsx
@@ -19,7 +19,6 @@ export const OrderRequestInfo = ({
   // 배송 요청사항 변경 핸들러
   const deliveryReqChangeHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { id } = e.target;
-    console.log(id);
     if (id === 'request-address') {
       setDeliveryReqState({ ...deliveryReqState, receiveAt: e.target.value });
     }

--- a/client/src/components/Order/OrderUser.tsx
+++ b/client/src/components/Order/OrderUser.tsx
@@ -26,7 +26,6 @@ export const OrderUser = ({
     e: React.ChangeEvent<HTMLInputElement>,
   ) => {
     const { id } = e.target;
-    console.log(id);
     if (id === 'order-user') {
       setOrdererInfoState({ ...ordererInfoState, name: e.target.value });
     }

--- a/client/src/pages/OrderPage/Order.tsx
+++ b/client/src/pages/OrderPage/Order.tsx
@@ -109,8 +109,8 @@ const Order = () => {
         const price = res.data.totalPrice;
         setPriceState({
           ...priceState,
-          shippingPrice: price,
-          totalPrice: price + 10000,
+          shippingPrice: 10000,
+          totalPrice: price,
         });
       })
       .catch((err) => {
@@ -170,7 +170,15 @@ const Order = () => {
           />
         </ContentLeft>
         <ContentRight>
-          <OrderPay priceState={priceState} clientPrice={clientPrice} />
+          <OrderPay
+            shippingState={shippingState}
+            ordererInfoState={ordererInfoState}
+            deliveryReqState={deliveryReqState}
+            clientPrice={clientPrice}
+            priceState={priceState}
+            productState={productState}
+            orderProduct={orderProduct}
+          />
         </ContentRight>
       </ContentWrap>
       <Footer />

--- a/client/src/pages/PaymentFinishedPage/PaymentFinished.tsx
+++ b/client/src/pages/PaymentFinishedPage/PaymentFinished.tsx
@@ -1,7 +1,7 @@
 const PaymentFinished = () => {
   return (
     <>
-      <h1>PaymentFinished</h1>
+      <h1>결제완료 페이지</h1>
       <span>hello</span>
     </>
   );

--- a/client/src/util/functions.tsx
+++ b/client/src/util/functions.tsx
@@ -1,3 +1,6 @@
+/* eslint-disable */
+import { OrderProducts } from './type';
+
 export const useComma = (price: number) => {
   return Number(price).toLocaleString('ko');
 };
@@ -19,4 +22,34 @@ export const convertDeliverStatus = (param: number) => {
     default:
       return '오류';
   }
+};
+
+//  order 주문 anme
+export const useName = (title: OrderProducts[]): string => {
+  if (title.length === 1) {
+    return `${title[0].title}`;
+  }
+
+  return `${title[0].title} 외 ${title.length - 1}개의 작품`;
+};
+
+// order 주문번호
+export const useOrderNumber = () => {
+  function generateRandomCode(n: number) {
+    let str = '';
+    for (let i = 0; i < n; i++) {
+      str += Math.floor(Math.random() * 10);
+    }
+    return str;
+  }
+
+  const today = new Date();
+  const year = today.getFullYear();
+  const month = ('0' + (today.getMonth() + 1)).slice(-2);
+  const day = ('0' + today.getDate()).slice(-2);
+
+  const dateStrng: string = year + month + day;
+
+  const productNum = generateRandomCode(6);
+  return `${dateStrng}${productNum}`;
 };

--- a/client/src/util/type.ts
+++ b/client/src/util/type.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 export interface Users {
   general?: {
     email: string;
@@ -238,4 +239,68 @@ export interface OrderProducts {
   price: number;
   title: string;
   _id: string;
+}
+
+//  IMPORT IMP.request_pay함수 첫번째 인자 type
+export interface RequestPayAdditionalParams {
+  digital?: boolean;
+  vbank_due?: string;
+  m_redirect_url?: string;
+  app_scheme?: string;
+  biz_num?: string;
+}
+
+export interface Display {
+  card_quota?: number[];
+}
+
+export interface RequestPayParams extends RequestPayAdditionalParams {
+  pg?: string;
+  pay_method: string;
+  escrow?: boolean;
+  merchant_uid: string;
+  name?: string;
+  amount: number;
+  custom_data?: any;
+  tax_free?: number;
+  currency?: string;
+  language?: string;
+  buyer_name?: string;
+  buyer_tel: string;
+  buyer_email?: string;
+  buyer_addr?: string;
+  buyer_postcode?: string;
+  notice_url?: string | string[];
+  display?: Display;
+}
+
+// IAMPORT 콜백 함수 정의 IMP.request_pay 함수의 두번째 인자 type
+export interface RequestPayAdditionalResponse {
+  apply_num?: string;
+  vbank_num?: string;
+  vbank_name?: string;
+  vbank_holder?: string | null;
+  vbank_date?: number;
+}
+
+export interface RequestPayResponse extends RequestPayAdditionalResponse {
+  success: boolean;
+  error_code: string;
+  error_msg: string;
+  imp_uid: string | null;
+  merchant_uid: string;
+  pay_method?: string;
+  paid_amount?: number;
+  status?: string;
+  name?: string;
+  pg_provider?: string;
+  pg_tid?: string;
+  buyer_name?: string;
+  buyer_email?: string;
+  buyer_tel?: string;
+  buyer_addr?: string;
+  buyer_postcode?: string;
+  custom_data?: any;
+  paid_at?: number;
+  receipt_url?: string;
 }

--- a/server/controllers/orderController.js
+++ b/server/controllers/orderController.js
@@ -10,6 +10,9 @@ import localTime from '../utils/localTime.js';
 const createOrder = asyncHandler(async (req, res) => {
   // 결제 후 주문 생성 단계
   const { orderItems } = req.body;
+  const { ordererInfo } = req.body;
+  console.log(ordererInfo);
+  console.log(orderItems);
 
   if (orderItems && !orderItems.length) {
     res.status(400).json({ message: '주문하실 상품을 추가해주세요' });

--- a/server/utils/generateToken.js
+++ b/server/utils/generateToken.js
@@ -2,7 +2,7 @@ import jwt from 'jsonwebtoken';
 
 // user._id를 통해 토큰 생성
 const generateAccessToken = (id) => {
-  return jwt.sign({ id }, process.env.JWT_SECRET_KEY, { expiresIn: '5s' });
+  return jwt.sign({ id }, process.env.JWT_SECRET_KEY, { expiresIn: '1h' });
 };
 
 export default generateAccessToken;


### PR DESCRIPTION


<!--
  PR 작성 가이드
1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
2. emoji, @어노테이션 등을 사용하여 효과적으로 소통할 것.
3. 명확하게 질문하고 명확하게 답변할 것.
4. 새로운 모듈 설치시 PR message에 기재할 것.
5. PR 올리기전에 branch 반드시 확인할 것. 
-->

## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
- Order 결제 버튼 기능 구현
## 👩‍💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
- 결제 요청
  - 결제 버튼 누를시 서버에 GET요청해서 품절 여부 + 결제 요청금액 일치하는지 확인(우리가 서버에게 받은 금액을 서버에게 다시 재확인 한다.)
  - 품절작품 O : 모달 알림 → 확인버튼 클릭 : 이전 페이지로 이동
  - 품절작품 X && 결제금액 일치 : 결제 API 로 이동
  -  결제금액 불일치 : 404 페이지
- 결제 완료
  - 유저가 입력한 주문 정보 서버에 추가 요청 → 성공/실패 응답
  - 로컬스토리지 cartitems 목록 중 양쪽 props와 중복되는 작품을 로컬스토리지에서 삭제
  - 결제 완료 페이지로 이동

close #59 

