### PR TITLE
[Fix] 콜백페이지 로딩이미지 가운데 정렬 Close #403

### DIFF
--- a/client/public/images/loading.svg
+++ b/client/public/images/loading.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="margin: auto; background: rgb(241, 242, 243); display: block; shape-rendering: auto; animation-play-state: running; animation-delay: 0s;" width="200px" height="200px" viewBox="0 0 100 100" preserveAspectRatio="xMidYMid">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="margin: auto; display: block; shape-rendering: auto; animation-play-state: running; animation-delay: 0s;" width="200px" height="200px" viewBox="0 0 100 100" preserveAspectRatio="xMidYMid">
 <g transform="translate(26.666666666666668,26.666666666666668)" style="animation-play-state: running; animation-delay: 0s;">
   <rect x="-20" y="-20" width="40" height="40" fill="#ee6123" style="animation-play-state: running; animation-delay: 0s;">
     <animateTransform attributeName="transform" type="scale" repeatCount="indefinite" dur="1s" keyTimes="0;1" values="1.1500000000000001;1" begin="-0.3s" style="animation-play-state: running; animation-delay: 0s;"></animateTransform>

--- a/client/src/pages/CallbackPage/Callback.tsx
+++ b/client/src/pages/CallbackPage/Callback.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import instance from 'util/axios';
 import { useRecoilState } from 'recoil';
 import { IsSigninState } from 'States/IsLoginState';
+import { CallbackContainer } from './styled';
 
 const Callback = () => {
   const [isLogin, setIsLogin] = useRecoilState(IsSigninState);
@@ -32,7 +33,11 @@ const Callback = () => {
       });
   }, []);
 
-  return <img src="/images/loading.svg" alt="Loading" />;
+  return (
+    <CallbackContainer>
+      <img src="/images/loading.svg" alt="Loading" />
+    </CallbackContainer>
+  );
 };
 
 export default Callback;

--- a/client/src/pages/CallbackPage/styled.ts
+++ b/client/src/pages/CallbackPage/styled.ts
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+
+export const CallbackContainer = styled.div`
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;


### PR DESCRIPTION
- 로딩이미지 백그라운드 색상 제거
- 로딩이미지 페이지 가운데 정렬

<!--
  PR 작성 가이드
1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
2. emoji, @어노테이션 등을 사용하여 효과적으로 소통할 것.
3. 명확하게 질문하고 명확하게 답변할 것.
4. 새로운 모듈 설치시 PR message에 기재할 것.
5. PR 올리기전에 branch 반드시 확인할 것. 
-->

## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
- 콜백페이지 로딩이미지 가운데 정렬
## 👩‍💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
- 로딩이미지 백그라운드 색상 제거
- 로딩이미지 페이지 가운데 정렬

