### PR TITLE
[Refact] JWT 토큰 검증 로직 수정 & CORS Origin Site 제한 Close #642 #643

### DIFF
--- a/server/controllers/orderController.js
+++ b/server/controllers/orderController.js
@@ -20,7 +20,9 @@ const createOrder = asyncHandler(async (req, res) => {
   }
   // 주문 생성
   req.body.totalPrice *= 1000;
-  const newOrder = await Order.create({ user: req.user._id, ...req.body });
+  // console.log('진짜', req.body.totalPrice);
+  // console.log(req.body);
+  const newOrder = await Order.create({ user: req.user.id, ...req.body });
   // 상품 재고 0으로 수정
   const itemsId = orderItems.map((item) => item.product);
   await Product.updateMany(
@@ -315,9 +317,9 @@ const getOrderById = asyncHandler(async (req, res) => {
 const getMyOrders = asyncHandler(async (req, res) => {
   const pageSize = 3;
   const page = Number(req.query.pageNumber) || 1;
-  const count = await Order.countDocuments({ user: req.user._id });
+  const count = await Order.countDocuments({ user: req.user.id });
   const orders = await Order.find(
-    { user: req.user._id },
+    { user: req.user.id },
     {
       deliveryInfo: 0,
       deliveryDetails: 0,
@@ -330,7 +332,7 @@ const getMyOrders = asyncHandler(async (req, res) => {
     .skip(pageSize * (page - 1))
     .exec();
   const status = await Order.aggregate([
-    { $match: { user: req.user._id } },
+    { $match: { user: req.user.id } },
     {
       $facet: {
         paid: [{ $match: { 'result.status': 0 } }, { $count: 'paid' }],
@@ -362,7 +364,7 @@ const getMyOrders = asyncHandler(async (req, res) => {
 // @access  Private
 const getLatestOrder = asyncHandler(async (req, res) => {
   const order = await Order.findOne(
-    { user: req.user._id },
+    { user: req.user.id },
     {
       deliveryInfo: 1,
       deliveryDetails: 1,

--- a/server/controllers/productController.js
+++ b/server/controllers/productController.js
@@ -119,7 +119,7 @@ const getProducts = asyncHandler(async (req, res) => {
 
   const { theme, sizeMin, sizeMax, priceMin, priceMax } = req.query;
 
-  let filter;
+  let filter = '';
 
   if (theme) {
     filter = { theme };
@@ -131,8 +131,6 @@ const getProducts = asyncHandler(async (req, res) => {
     filter = { price: { $gte: Number(priceMin), $lte: Number(priceMax) } };
   } else if (priceMin) {
     filter = { price: { $gte: Number(priceMin) } };
-  } else {
-    filter = '';
   }
 
   pageSize = 28;
@@ -175,7 +173,7 @@ const getProducts = asyncHandler(async (req, res) => {
     res.json({
       products,
       page,
-      pages: Math.ceil(count ? count[0].of_products : 1 / pageSize),
+      pages: 1,
     });
     return;
   }

--- a/server/index.js
+++ b/server/index.js
@@ -23,13 +23,17 @@ const combined =
 const morganFormat = process.env.NODE_ENV !== 'production' ? 'dev' : combined;
 
 const app = express();
-app.use(express.urlencoded({ extended: true }));
 app.use(express.json());
+app.use(express.urlencoded({ extended: true })); // qs
 app.use(morgan(morganFormat, { stream: logger.stream })); // morgan 로그 설정
 
 app.use(
   cors({
-    origin: '*',
+    origin: [
+      'https://lumiereimage.s3.ap-northeast-2.amazonaws.com',
+      'https://www.lumieregallery.site',
+      'http://localhost:3000',
+    ],
     methods: ['GET', 'POST', 'PATCH', 'DELETE', 'OPTIONS'],
   }),
 );

--- a/server/middleware/auth.js
+++ b/server/middleware/auth.js
@@ -1,9 +1,8 @@
 import jwt from 'jsonwebtoken';
 import asyncHandler from 'express-async-handler';
-import User from '../models/user.js';
 
 // 로그인 유저만 private route 접근을 허락해주는 함수
-// 토큰 정보를 받아서 해독하고 검증한다.
+// 토큰 유무와 유효성 검사
 
 const protect = asyncHandler(async (req, res, next) => {
   let token;
@@ -13,12 +12,7 @@ const protect = asyncHandler(async (req, res, next) => {
     try {
       // eslint-disable-next-line prefer-destructuring
       token = authorization.split(' ')[1];
-      const decoded = jwt.verify(token, process.env.JWT_SECRET_KEY);
-      // console.log(decoded);
-      req.user = await User.findById(decoded.id).select(
-        '-general.password -google.accessToken  -naver.accessToken -kakao.accessToken -google.refreshToken -naver.refreshToken -kakao.refreshToken',
-      );
-      // console.log('req.user 객체에는?', req.user);
+      req.user = jwt.verify(token, process.env.JWT_SECRET_KEY);
       next();
     } catch (error) {
       console.error(error);

--- a/server/utils/generateToken.js
+++ b/server/utils/generateToken.js
@@ -1,8 +1,9 @@
 import jwt from 'jsonwebtoken';
 
-// user._id를 통해 토큰 생성
-const generateAccessToken = (id) => {
-  return jwt.sign({ id }, process.env.JWT_SECRET_KEY, { expiresIn: '1d' });
+const generateAccessToken = (id, isAdmin) => {
+  return jwt.sign({ id, isAdmin }, process.env.JWT_SECRET_KEY, {
+    expiresIn: '3h',
+  });
 };
 
 export default generateAccessToken;


### PR DESCRIPTION
<!--
  PR 작성 가이드
1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
2. emoji, @어노테이션 등을 사용하여 효과적으로 소통할 것.
3. 명확하게 질문하고 명확하게 답변할 것.
4. 새로운 모듈 설치시 PR message에 기재할 것.
5. PR 올리기전에 branch 반드시 확인할 것. 
-->

## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
- [Refact] JWT 토큰 검증 로직 수정 & CORS Origin Site 제한
## 👩‍💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
- JWT의 사용 이유를 다시 생각하고 장점에 맞게 로직 변경
- 발행된 토큰이 유효하다면, 서버는 토큰 유무만으로 권한 제공해야 한다.
- 토큰은 시그니처 사인으로 신뢰성을 입증하기 때문에, 보낸이가 누군지 데이터가 조작되지 않았는지 검증할 수 있다.
- 따라서 확인을 위해 DB에 해당 유저를 조회하는 부분 삭제
-----
- CORS Origin 전체 허용에서 우리의 S3와 클라이언트 주소만 허용하는 것으로 수정
## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
- 이벤트 핸들러 진입 전, 인가를 맡은 Auth 커스텀 미들웨어 로직에서 페이로드 정보로 DB 조회하는 부분 삭제
- 토큰 생성 함수인 generateAccessToken에 인자로 isAdmin을 추가해 verify 시 바로 권한을 알 수 있도록 수정
- verify 한 데이터를 req.user로 담아 다음 미들웨어로 보내고(next), 
- 비즈니스 로직에서 유저의 ObjectID로 DB 조회가 필요할 경우에 사용

